### PR TITLE
Don't remove LAME: add calls to remove Lame for Audacity from $Result…

### DIFF
--- a/CLIENT_DATA/common.opsiinc
+++ b/CLIENT_DATA/common.opsiinc
@@ -1,4 +1,4 @@
-requiredWinstVersion >= "4.11.4.3"
+requiredWinstVersion >= "4.11.5.1"
 
 DefVar $UninstallProgram$
 DefVar $InstallProgram$

--- a/CLIENT_DATA/delsub32.opsiscript
+++ b/CLIENT_DATA/delsub32.opsiscript
@@ -5,6 +5,7 @@ Set $SearchPattern$ = $ProductName$
 Sub_search_registry32_uninstall_keys
 ; Rückgabewert: $ResultList$ gefundene Einträge
 
+set $ResultList$ = removeFromListByContaining("LAME", $ResultList$)
 Switch count ($ResultList$)
 	Case "0"
 		comment "No installations of " + $SearchPattern$ + " found in $RegPathUninstall$. Nothing to do ;-)"

--- a/CLIENT_DATA/setup32.opsiscript
+++ b/CLIENT_DATA/setup32.opsiscript
@@ -22,6 +22,7 @@ else
 	; Parameter: $SearchPattern$ Suchbegriff in Registry
 	Sub_search_registry32_uninstall_keys
 	; Rückgabewert: $ResultList$ gefundene Einträge
+	set $ResultList$ = removeFromListByContaining("LAME", $ResultList$)
 
 	Switch count ($ResultList$)
 		Case "0"


### PR DESCRIPTION
…List$ after searching registry

Hi, I found a bug in your audacity package when used together with Lame for Audacity. Because it has "Audacity" in the name it ends up in $ResultList$, causing the opsi package to either:
1) Remove Lame for Audacity if it's installed
2) Fail because it thinks it has found more than one Audacity installation

The patch resolves this by removing Lame for Audacity from $ResultList$. The requiredWinstVersion is bumped because of using the removeFromListByContaining function.